### PR TITLE
Added warning for possible fix when having issues on different terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ Linking order: main.obj, fact.obj, print.obj, stack.obj, ending.obj
 * Author: Nejc Kišek
 
 ### Brainfuck Language Interpreter
-Executes an arbitrary program written in [Brainfuck language](https://en.wikipedia.org/wiki/Brainfuck). Upon starting, program waits for input to stdin (console input). **Paste or type the program as a single line, ending the entry sequence by pressing `Enter` (EOT character)**. Interpreter will read and execute the program.  When/if Brainfuck program finishes, interpreter will wait for next program to be entered. 
+Executes an arbitrary program written in [Brainfuck language](https://en.wikipedia.org/wiki/Brainfuck). Upon starting, program waits for input to stdin (console input). **Paste or type the program as a single line, ending the entry sequence by pressing `Enter`**. Interpreter will read and execute the program.  When/if Brainfuck program finishes, interpreter will wait for next program to be entered. 
 
 Tape size and instruction stack size are limited to 400 Bytes each (400 cells and 400 separate instructions). For more, resize `stackstart` and `tape#` variables. 
+
+**Program has been observed having trouble ending input on UNIX/UNIX-like systems and some IDEs. If you have trouble using the program, try changing the value in line 144 from 0x0D (carriage return) to 0x0A (new line).**
 
 * Source code: brainfuck.asm
 * Frequency: Depending on program, generally recommended at least 10000 Hz (10 kHz)


### PR DESCRIPTION
We have observed that the brainfuck.asm program would sometimes not end the input while reading from stdin.

It has been determined that the issue lies in comparing input with 0x0D character in line 144. Generally, 0x0D (carriage return/EOT) works with Windows and Cygwin terminals, while some IDEs and UNIX systems use 0x0A (new line) character. Thus, warning has been added to README.md.